### PR TITLE
Add debug logging for dataset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ metrics are intentionally left as placeholders so the team can extend them later
 └── .gitignore
 ```
 
+## Loading Dataset
+
+The `models` package includes a helper function `load_and_label_data` that
+collects training data from folders named `Positive` and `Negative` inside a
+given directory. Data in `Positive` is labeled as *fault* while data in
+`Negative` is labeled as *normal*. The function returns both the loaded
+``pandas.DataFrame`` and a dictionary with counts of normal and fault files.
+The GUI uses these counts to display a confirmation message after the training
+folder is selected. When ``verbose`` is ``True`` the helper reports these
+counts using Python's ``logging`` module.
+
 ## Running
 
 Install dependencies and start the GUI:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,5 +1,7 @@
 from PyQt5 import QtWidgets
 
+from models import load_and_label_data
+
 class MainWindow(QtWidgets.QMainWindow):
     """Main application window with placeholders for ML workflow."""
 
@@ -49,9 +51,21 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addWidget(self.results)
 
     def select_train_folder(self):
-        folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Train Folder")
+        folder = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Select Train Folder"
+        )
         if folder:
+            data, counts = load_and_label_data(folder, verbose=True)
+            self.train_data = data
+            message = (
+                f"{counts['normal']} normal files and "
+                f"{counts['fault']} fault files detected."
+            )
+            QtWidgets.QMessageBox.information(
+                self, "Training Data Loaded", message
+            )
             self.train_edit.setText(folder)
+            self.results.append(message)
 
     def select_test_folder(self):
         folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Test Folder")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,3 @@
+from .data_loader import load_and_label_data
+
+__all__ = ["load_and_label_data"]

--- a/models/data_loader.py
+++ b/models/data_loader.py
@@ -1,0 +1,76 @@
+import os
+import logging
+import pandas as pd
+import scipy.io
+
+logger = logging.getLogger(__name__)
+
+
+def load_and_label_data(base_path, verbose=True):
+    """Load ``.mat`` files from Positive and Negative subfolders.
+
+    The function expects two directories inside ``base_path`` named
+    ``Positive`` and ``Negative``. Files found under ``Positive`` are labeled
+    as faults and files found under ``Negative`` are labeled as normal.
+
+    Parameters
+    ----------
+    base_path : str
+        Path containing the ``Positive`` and ``Negative`` folders.
+
+    Returns
+    -------
+    tuple[pandas.DataFrame, dict]
+        Combined data from all files with a ``label`` column and a dictionary
+        with counts of ``fault`` and ``normal`` files.
+
+    Notes
+    -----
+    Set ``verbose`` to ``True`` to log a summary of loaded files using the
+    standard ``logging`` module.
+    """
+    data_frames = []
+    counts = {"fault": 0, "normal": 0}
+
+    for subfolder in ["Positive", "Negative"]:
+        folder_path = os.path.join(base_path, subfolder)
+        if not os.path.isdir(folder_path):
+            continue
+
+        label = "fault" if subfolder == "Positive" else "normal"
+        for file in os.listdir(folder_path):
+            if file.endswith(".mat"):
+                file_path = os.path.join(folder_path, file)
+                mat_data = scipy.io.loadmat(file_path)
+
+                data_array = mat_data["dataset"]
+                df = pd.DataFrame(
+                    data_array,
+                    columns=[
+                        "sample_num",
+                        "Acc_X",
+                        "Acc_Y",
+                        "Acc_Z",
+                        "Gyro_X",
+                        "Gyro_Y",
+                        "Gyro_Z",
+                    ],
+                )
+                df["label"] = label
+                df["source_file"] = file
+                data_frames.append(df)
+                counts[label] += 1
+
+    if data_frames:
+        combined = pd.concat(data_frames, ignore_index=True)
+    else:
+        combined = pd.DataFrame()
+
+    if verbose:
+        logger.info(
+            "Loaded %s normal files and %s fault files.",
+            counts["normal"],
+            counts["fault"],
+        )
+
+    return combined, counts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 PyQt5>=5.15
+pandas
+scipy

--- a/run_gui.py
+++ b/run_gui.py
@@ -1,9 +1,11 @@
 from PyQt5 import QtWidgets
+import logging
 
 from gui.main_window import MainWindow
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     app = QtWidgets.QApplication([])
     window = MainWindow()
     window.show()


### PR DESCRIPTION
## Summary
- log dataset load counts using Python logging
- display load summary in the results panel
- enable logging in `run_gui.py`
- document verbose logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844514e73d48330bdac944fc1af128c