### PR TITLE
Resolve merge conflicts in README and data loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ metrics are intentionally left as placeholders so the team can extend them later
 The `models` package includes a helper function `load_and_label_data` that
 collects training data from folders named `Positive` and `Negative` inside a
 given directory. Data in `Positive` is labeled as *fault* while data in
-`Negative` is labeled as *normal*. After loading, the function prints how many
-files were found for each label.
+`Negative` is labeled as *normal*. The function returns both the loaded
+``pandas.DataFrame`` and a dictionary with counts of normal and fault files.
+When ``verbose`` is ``True`` these counts are logged using Python's
+``logging`` module and displayed in the GUI after selecting the training folder.
 
 ## Running
 

--- a/models/data_loader.py
+++ b/models/data_loader.py
@@ -1,10 +1,13 @@
 import os
+import logging
 import pandas as pd
 import scipy.io
 
+logger = logging.getLogger(__name__)
 
-def load_and_label_data(base_path):
-    """Load .mat files from Positive and Negative subfolders.
+
+def load_and_label_data(base_path, verbose=True):
+    """Load ``.mat`` files from Positive and Negative subfolders.
 
     The function expects two directories inside ``base_path`` named
     ``Positive`` and ``Negative``. Files found under ``Positive`` are labeled
@@ -17,8 +20,14 @@ def load_and_label_data(base_path):
 
     Returns
     -------
-    pandas.DataFrame
-        Combined data from all files with a ``label`` column.
+    tuple[pandas.DataFrame, dict]
+        Combined data from all files with a ``label`` column and a dictionary
+        with counts of ``fault`` and ``normal`` files.
+
+    Notes
+    -----
+    Set ``verbose`` to ``True`` to log a summary of loaded files using the
+    standard ``logging`` module.
     """
     data_frames = []
     counts = {"fault": 0, "normal": 0}
@@ -57,5 +66,11 @@ def load_and_label_data(base_path):
     else:
         combined = pd.DataFrame()
 
-    print(f"Loaded {counts['normal']} normal files and {counts['fault']} fault files.")
-    return combined
+    if verbose:
+        logger.info(
+            "Loaded %s normal files and %s fault files.",
+            counts["normal"],
+            counts["fault"],
+        )
+
+    return combined, counts


### PR DESCRIPTION
## Summary
- merge in updates from the dataset loader branch
- keep verbose logging and return counts in `load_and_label_data`
- update README with logging/return info

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445e6bd8108330bd85ab3edd64cee9