### PR TITLE
Show dataset summary when selecting training folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ metrics are intentionally left as placeholders so the team can extend them later
 ## Loading Dataset
 
 The `models` package includes a helper function `load_and_label_data` that
-collects training data from folders named `Positive` and `Negative` inside a
-given directory. Data in `Positive` is labeled as *fault* while data in
-`Negative` is labeled as *normal*. The function returns both the loaded
-``pandas.DataFrame`` and a dictionary with counts of normal and fault files.
+collects training data from folders named `Positive` and `Negative` (or the
+alternative `fault`/`normal`) inside a given directory. Data in the fault
+folders is labeled as *fault* while data in the normal folders is labeled as
+*normal*. The function returns both the loaded ``pandas.DataFrame`` and a
+dictionary with counts of normal and fault files.
 When ``verbose`` is ``True`` these counts are logged using Python's
 ``logging`` module and displayed in the GUI after selecting the training folder.
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,5 +1,7 @@
 from PyQt5 import QtWidgets
 
+from models import load_and_label_data
+
 class MainWindow(QtWidgets.QMainWindow):
     """Main application window with placeholders for ML workflow."""
 
@@ -7,6 +9,7 @@ class MainWindow(QtWidgets.QMainWindow):
         super().__init__()
         self.setWindowTitle("KNTU ML Trainer")
         self.resize(600, 400)
+        self.dataset_counts = None
         self._init_ui()
 
     def _init_ui(self):
@@ -52,6 +55,11 @@ class MainWindow(QtWidgets.QMainWindow):
         folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Train Folder")
         if folder:
             self.train_edit.setText(folder)
+            _, counts = load_and_label_data(folder, verbose=False)
+            self.dataset_counts = counts
+            self.results.append(
+                f"Loaded {counts['normal']} normal files and {counts['fault']} fault files."
+            )
 
     def select_test_folder(self):
         folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Test Folder")

--- a/models/data_loader.py
+++ b/models/data_loader.py
@@ -7,11 +7,13 @@ logger = logging.getLogger(__name__)
 
 
 def load_and_label_data(base_path, verbose=True):
-    """Load ``.mat`` files from Positive and Negative subfolders.
+"""Load ``.mat`` files from subfolders containing normal and fault data.
 
-    The function expects two directories inside ``base_path`` named
-    ``Positive`` and ``Negative``. Files found under ``Positive`` are labeled
-    as faults and files found under ``Negative`` are labeled as normal.
+    By default the function looks for ``Positive``/``Negative`` folders but it
+    also accepts the more explicit ``fault``/``normal`` naming. Any of these
+    directories will be processed if present within ``base_path``. Files found
+    under a fault folder are labeled as faults and files found under a normal
+    folder are labeled as normal.
 
     Parameters
     ----------
@@ -32,12 +34,19 @@ def load_and_label_data(base_path, verbose=True):
     data_frames = []
     counts = {"fault": 0, "normal": 0}
 
-    for subfolder in ["Positive", "Negative"]:
+    for subfolder in os.listdir(base_path):
         folder_path = os.path.join(base_path, subfolder)
         if not os.path.isdir(folder_path):
             continue
 
-        label = "fault" if subfolder == "Positive" else "normal"
+        name = subfolder.lower()
+        if name in {"positive", "fault"}:
+            label = "fault"
+        elif name in {"negative", "normal"}:
+            label = "normal"
+        else:
+            continue
+
         for file in os.listdir(folder_path):
             if file.endswith(".mat"):
                 file_path = os.path.join(folder_path, file)


### PR DESCRIPTION
## Summary
- display number of normal and fault samples after choosing the train folder
- allow `load_and_label_data` to work with `fault/normal` directories in addition to `Positive/Negative`
- clarify README with the new directory names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684460d67bc883309e23c0c3265df884