### PR TITLE
Handle non-interactive matplotlib backend

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -221,5 +221,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         preds = grid.predict(X)
         cm = confusion_matrix(y, preds)
-        plot_confusion(cm, model_name)
-        plt.show()
+        fig = plot_confusion(cm, model_name)
+        if "agg" not in plt.get_backend().lower():
+            plt.show()
+        else:
+            fig.savefig("confusion_matrix.png")
+            self.results.append(
+                "Confusion matrix saved to confusion_matrix.png (non-interactive backend)."
+            )


### PR DESCRIPTION
## Summary
- prevent warnings when running with the Agg backend by checking the backend before calling `plt.show`
- save the confusion matrix plot to `confusion_matrix.png` when an interactive backend is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447e5625a4833087bed087f00a0505