### PR TITLE
Enable viewing confusion matrix in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ dictionary with counts of normal and fault files.
 When ``verbose`` is ``True`` these counts are logged using Python's
 ``logging`` module and displayed in the GUI after selecting the training folder.
 
+After each training run the confusion matrix is displayed in a modal window.
+The window includes the standard matplotlib toolbar allowing the image to be
+saved directly from the interface when a graphical backend is available.  When
+running without a display, the matrix is written to ``confusion_matrix.png``.
+
 ## Running
 
 Install dependencies and start the GUI:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -165,6 +165,22 @@ class MainWindow(QtWidgets.QMainWindow):
         self.results.setReadOnly(True)
         layout.addWidget(self.results)
 
+    def _display_figure(self, fig):
+        """Show a matplotlib figure in a modal dialog with save option."""
+        from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg, NavigationToolbar2QT
+
+        dialog = QtWidgets.QDialog(self)
+        dialog.setWindowTitle("Confusion Matrix")
+        layout = QtWidgets.QVBoxLayout(dialog)
+
+        canvas = FigureCanvasQTAgg(fig)
+        toolbar = NavigationToolbar2QT(canvas, dialog)
+
+        layout.addWidget(toolbar)
+        layout.addWidget(canvas)
+        dialog.resize(600, 500)
+        dialog.exec_()
+
     def select_train_folder(self):
         folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Train Folder")
         if folder:
@@ -225,7 +241,10 @@ class MainWindow(QtWidgets.QMainWindow):
         if "agg" not in plt.get_backend().lower():
             plt.show()
         else:
-            fig.savefig("confusion_matrix.png")
-            self.results.append(
-                "Confusion matrix saved to confusion_matrix.png (non-interactive backend)."
-            )
+            if QtWidgets.QApplication.instance() is not None:
+                self._display_figure(fig)
+            else:
+                fig.savefig("confusion_matrix.png")
+                self.results.append(
+                    "Confusion matrix saved to confusion_matrix.png (non-interactive backend)."
+                )


### PR DESCRIPTION
## Summary
- embed confusion matrix figure in a Qt dialog when using a non-interactive backend
- mention the new interactive display in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844850b1e90833080bdb339a2da7ae5