### PR TITLE
Enhance GUI with test folder predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The window includes the standard matplotlib toolbar allowing the image to be
 saved directly from the interface when a graphical backend is available.  When
 running without a display, the matrix is written to ``confusion_matrix.png``.
 
+When a test folder is selected, each subfolder of unlabeled ``.mat`` files is
+predicted after training. The results are shown in the GUI as a small table with
+the folder name and the assigned label.
+
 ## Running
 
 Install dependencies and start the GUI:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,3 @@
-from .data_loader import load_and_label_data
+from .data_loader import load_and_label_data, load_test_data
 
-__all__ = ["load_and_label_data"]
+__all__ = ["load_and_label_data", "load_test_data"]

--- a/models/data_loader.py
+++ b/models/data_loader.py
@@ -83,3 +83,39 @@ def load_and_label_data(base_path, verbose=True):
         )
 
     return combined, counts
+
+
+def load_test_data(base_path):
+    """Load ``.mat`` files from subfolders without assigning labels."""
+    data_frames = []
+
+    for subfolder in os.listdir(base_path):
+        folder_path = os.path.join(base_path, subfolder)
+        if not os.path.isdir(folder_path):
+            continue
+
+        for file in os.listdir(folder_path):
+            if file.endswith(".mat"):
+                file_path = os.path.join(folder_path, file)
+                mat_data = scipy.io.loadmat(file_path)
+
+                data_array = mat_data["dataset"]
+                df = pd.DataFrame(
+                    data_array,
+                    columns=[
+                        "sample_num",
+                        "Acc_X",
+                        "Acc_Y",
+                        "Acc_Z",
+                        "Gyro_X",
+                        "Gyro_Y",
+                        "Gyro_Z",
+                    ],
+                )
+                df["folder"] = subfolder
+                df["source_file"] = file
+                data_frames.append(df)
+
+    if data_frames:
+        return pd.concat(data_frames, ignore_index=True)
+    return pd.DataFrame()


### PR DESCRIPTION
## Summary
- support loading of unlabeled data via `load_test_data`
- show predicted label for each test subfolder after training
- document new feature in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448ac4777483308db2f7c9d10b1019