### PR TITLE
Fix test data loading logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ The window includes the standard matplotlib toolbar allowing the image to be
 saved directly from the interface when a graphical backend is available.  When
 running without a display, the matrix is written to ``confusion_matrix.png``.
 
-When a test folder is selected, each subfolder of unlabeled ``.mat`` files is
-predicted after training. The results are shown in the GUI as a small table with
-the folder name and the assigned label.
+When a test folder is selected, ``.mat`` files can either be placed directly in
+the directory or organised into subfolders.  If folders named
+``normal``/``fault`` (or their ``Negative``/``Positive`` variants) are
+present, the files are treated as labeled and a confusion matrix for the test
+data is displayed.  Otherwise each folder is predicted and the assigned label is
+listed in a small table.
 
 ## Running
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,31 @@
+import numpy as np
+from scipy.io import savemat
+from models import load_test_data
+
+
+def _make_mat(path):
+    data = np.ones((1, 7))
+    savemat(path, {"dataset": data})
+
+
+def test_load_test_data_with_files_in_root(tmp_path):
+    mat_path = tmp_path / "sample.mat"
+    _make_mat(mat_path)
+
+    df = load_test_data(tmp_path)
+    assert not df.empty
+    assert df["folder"].iloc[0] == tmp_path.name
+    assert "label" not in df.columns or df["label"].isna().all()
+
+
+def test_load_test_data_with_labelled_folders(tmp_path):
+    normal_dir = tmp_path / "normal"
+    normal_dir.mkdir()
+    fault_dir = tmp_path / "fault"
+    fault_dir.mkdir()
+    _make_mat(normal_dir / "n.mat")
+    _make_mat(fault_dir / "f.mat")
+
+    df = load_test_data(tmp_path)
+    assert set(df["label"]) == {"normal", "fault"}
+


### PR DESCRIPTION
## Summary
- improve `load_test_data` to support labeled folders and direct files
- show confusion matrix for labeled test data in the GUI
- document the new behaviour in README
- add unit tests for `load_test_data`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448f011e4083308dd4669c7b5b8ca1