### PR TITLE
Add debug logs for prediction results

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -3,6 +3,10 @@ from PyQt5 import QtWidgets, QtCore
 from models import load_and_label_data, load_test_data
 from features import extract_features
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.tree import DecisionTreeClassifier
@@ -320,6 +324,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 label = "fault" if group["pred"].mean() >= 0.5 else "normal"
                 file_predictions.append((folder_name, file_name, label))
             data_for_cm = data
+
+        for folder, file, label in file_predictions:
+            logger.debug("Predicted %s for %s/%s", label, folder, file)
+        labels = [lbl for _, _, lbl in file_predictions]
+        logger.info(
+            "Prediction summary - normal: %s, fault: %s",
+            labels.count("normal"),
+            labels.count("fault"),
+        )
 
         html = [
             "<h3>Test File Predictions</h3>",

--- a/run_gui.py
+++ b/run_gui.py
@@ -1,9 +1,14 @@
 from PyQt5 import QtWidgets
+import logging
 
 from gui.main_window import MainWindow
 
 
 def main():
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
     app = QtWidgets.QApplication([])
     window = MainWindow()
     window.show()


### PR DESCRIPTION
## Summary
- configure logging in `run_gui.py`
- log predicted labels and summary counts when running test predictions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684499ad55c08330b3623250549a9c79