### PR TITLE
Expand hyperparameter grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 This project provides a simple PyQt based GUI skeleton for machine learning workflows.
 The interface allows users to select training and test folders, choose a model type
 from a list of common classifiers and load a pretrained model. Training logic now
-includes a basic grid search to tune hyperparameters for the selected model.
+includes a grid search to tune hyperparameters for the selected model. The search
+space was recently expanded with more options for each estimator so you can
+experiment with deeper trees, different SVM kernels and additional boosting
+settings.
 
 ## Structure
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -68,45 +68,56 @@ param_grids = {
     "DecisionTree": {
         "clf__max_depth": [3, 5, 10, None],
         "clf__min_samples_split": [2, 5, 10],
+        "clf__min_samples_leaf": [1, 2, 4],
     },
     "RandomForest": {
         "clf__n_estimators": [50, 100, 200],
         "clf__max_depth": [3, 5, 10, None],
         "clf__min_samples_split": [2, 5, 10],
+        "clf__max_features": ["sqrt", "log2", None],
     },
     "AdaBoost": {
         "clf__n_estimators": [50, 100, 200],
         "clf__learning_rate": [0.01, 0.1, 1.0],
+        "clf__algorithm": ["SAMME", "SAMME.R"],
     },
     "MLP": {
         "clf__hidden_layer_sizes": [(50,), (100,), (50, 50)],
         "clf__activation": ["relu", "tanh"],
         "clf__alpha": [0.0001, 0.001, 0.01],
+        "clf__learning_rate_init": [0.001, 0.01],
     },
     "SVM": {
         "clf__C": [0.1, 1, 10],
-        "clf__kernel": ["linear", "rbf"],
+        "clf__kernel": ["linear", "rbf", "poly"],
         "clf__gamma": ["scale", "auto"],
+        "clf__degree": [3, 5],
     },
     "GradientBoosting": {
         "clf__n_estimators": [100, 200],
         "clf__learning_rate": [0.01, 0.1, 0.2],
         "clf__max_depth": [3, 5, 7],
+        "clf__subsample": [0.8, 1.0],
     },
     "XGBoost": {
         "clf__n_estimators": [50, 100, 200],
         "clf__max_depth": [3, 5, 7],
         "clf__learning_rate": [0.01, 0.1, 0.2],
+        "clf__subsample": [0.8, 1.0],
+        "clf__colsample_bytree": [0.8, 1.0],
     },
     "LightGBM": {
         "clf__n_estimators": [50, 100, 200],
         "clf__max_depth": [3, 5, 7],
         "clf__learning_rate": [0.01, 0.1, 0.2],
+        "clf__num_leaves": [31, 63],
+        "clf__subsample": [0.8, 1.0],
     },
     "CatBoost": {
         "clf__iterations": [50, 100, 200],
         "clf__depth": [3, 5, 7],
         "clf__learning_rate": [0.01, 0.1, 0.2],
+        "clf__l2_leaf_reg": [1, 3, 5],
     },
 }
 


### PR DESCRIPTION
## Summary
- expand README with note about broader hyperparameter search space
- extend `param_grids` for all classifiers with additional tuning options

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a8e6d91483308b07cb5e77206bc0