### PR TITLE
Add optional GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ Install dependencies and start the GUI:
 pip install -r requirements.txt
 python run_gui.py
 ```
+
+If an NVIDIA GPU is detected, supported models (XGBoost, LightGBM and
+CatBoost) will automatically train on the GPU.  The GUI displays whether
+training is running on GPU or CPU at the start of each run.


### PR DESCRIPTION
## Summary
- detect if an NVIDIA GPU is available
- use GPU for XGBoost, LightGBM and CatBoost when possible
- report GPU/CPU mode in the GUI
- mention GPU usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ac6f9d24833097eb83d250ad5685