### PR TITLE
Add sensor data visualization window

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ python run_gui.py
 If an NVIDIA GPU is detected, supported models (XGBoost, LightGBM and
 CatBoost) will automatically train on the GPU.  The GUI displays whether
 training is running on GPU or CPU at the start of each run.
+
+## Data Visualisation
+
+Use the **Visualize Data** button to explore sensor data before training. A new
+window lets you load either train or test folders. Select a file from the list
+and choose which sensors to plot to quickly inspect the raw signals.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,1 +1,4 @@
+from .main_window import MainWindow
+from .data_viewer import DataViewer
 
+__all__ = ["MainWindow", "DataViewer"]

--- a/gui/data_viewer.py
+++ b/gui/data_viewer.py
@@ -1,0 +1,106 @@
+from PyQt5 import QtWidgets, QtCore
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from models import load_and_label_data, load_test_data
+from features import SENSOR_COLS
+
+
+class DataViewer(QtWidgets.QDialog):
+    """Simple window to visualise sensor data from train/test folders."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Data Viewer")
+        self.resize(800, 600)
+        self.data = pd.DataFrame()
+        self._init_ui()
+
+    def _init_ui(self):
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # Top controls
+        controls = QtWidgets.QHBoxLayout()
+        self.type_combo = QtWidgets.QComboBox()
+        self.type_combo.addItems(["Train", "Test"])
+        self.path_edit = QtWidgets.QLineEdit()
+        select_btn = QtWidgets.QPushButton("Select Folder")
+        select_btn.clicked.connect(self.select_folder)
+        controls.addWidget(self.type_combo)
+        controls.addWidget(self.path_edit)
+        controls.addWidget(select_btn)
+        layout.addLayout(controls)
+
+        # Sensor check boxes
+        sensor_layout = QtWidgets.QHBoxLayout()
+        self.sensor_checks = {}
+        for sensor in SENSOR_COLS:
+            cb = QtWidgets.QCheckBox(sensor)
+            cb.setChecked(True)
+            cb.stateChanged.connect(self.update_plot)
+            sensor_layout.addWidget(cb)
+            self.sensor_checks[sensor] = cb
+        layout.addLayout(sensor_layout)
+
+        # File list and plot area
+        main = QtWidgets.QHBoxLayout()
+        self.file_list = QtWidgets.QListWidget()
+        self.file_list.currentItemChanged.connect(self.update_plot)
+        main.addWidget(self.file_list, 1)
+
+        from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+
+        self.figure = plt.Figure(figsize=(5, 4))
+        self.canvas = FigureCanvasQTAgg(self.figure)
+        main.addWidget(self.canvas, 3)
+        layout.addLayout(main)
+
+    def select_folder(self):
+        folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Folder")
+        if not folder:
+            return
+        self.path_edit.setText(folder)
+        if self.type_combo.currentText() == "Train":
+            self.data, _ = load_and_label_data(folder, verbose=False)
+        else:
+            self.data = load_test_data(folder)
+        self.populate_file_list()
+
+    def populate_file_list(self):
+        self.file_list.clear()
+        if self.data.empty:
+            return
+        if "folder" in self.data.columns:
+            group = self.data.groupby(["folder", "source_file"])
+        else:
+            group = self.data.groupby(["source_file"])
+        for keys, g in group:
+            if isinstance(keys, tuple):
+                folder, file = keys
+            else:
+                folder, file = "", keys
+            label = g["label"].iloc[0] if "label" in g.columns else None
+            text = f"{folder}/{file}" if folder else file
+            if label is not None:
+                text += f" - {label}"
+            item = QtWidgets.QListWidgetItem(text)
+            item.setData(QtCore.Qt.UserRole, (folder, file))
+            self.file_list.addItem(item)
+
+    def update_plot(self, *args):
+        item = self.file_list.currentItem()
+        if item is None or self.data.empty:
+            return
+        folder, file = item.data(QtCore.Qt.UserRole)
+        if folder:
+            df = self.data[(self.data["folder"] == folder) & (self.data["source_file"] == file)]
+        else:
+            df = self.data[self.data["source_file"] == file]
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        for sensor, cb in self.sensor_checks.items():
+            if cb.isChecked() and sensor in df.columns:
+                ax.plot(df["sample_num"], df[sensor], label=sensor)
+        ax.set_xlabel("Sample")
+        ax.legend()
+        self.canvas.draw()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -2,6 +2,7 @@ from PyQt5 import QtWidgets, QtCore
 
 from models import load_and_label_data, load_test_data
 from features import extract_features
+from gui.data_viewer import DataViewer
 
 import logging
 import shutil
@@ -231,6 +232,11 @@ class MainWindow(QtWidgets.QMainWindow):
         train_model_btn.clicked.connect(self.train_model)
         layout.addWidget(train_model_btn)
 
+        # Data visualisation window
+        view_btn = QtWidgets.QPushButton("Visualize Data")
+        view_btn.clicked.connect(self.open_viewer)
+        layout.addWidget(view_btn)
+
         # Placeholder for results
         self.results = QtWidgets.QTextEdit()
         self.results.setReadOnly(True)
@@ -251,6 +257,11 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addWidget(canvas)
         dialog.resize(600, 500)
         dialog.exec_()
+
+    def open_viewer(self):
+        """Launch the :class:`DataViewer` dialog."""
+        viewer = DataViewer(self)
+        viewer.exec_()
 
     def select_train_folder(self):
         folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Train Folder")

--- a/tests/test_data_viewer.py
+++ b/tests/test_data_viewer.py
@@ -1,0 +1,32 @@
+import matplotlib
+matplotlib.use('Agg')
+
+import os
+from PyQt5 import QtWidgets
+import pandas as pd
+
+from gui.data_viewer import DataViewer
+
+
+def test_viewer_populates_list():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    viewer = DataViewer()
+    df = pd.DataFrame({
+        'sample_num': [0, 1],
+        'Acc_X': [0, 1],
+        'Acc_Y': [0, 1],
+        'Acc_Z': [0, 1],
+        'Gyro_X': [0, 1],
+        'Gyro_Y': [0, 1],
+        'Gyro_Z': [0, 1],
+        'folder': ['f', 'f'],
+        'source_file': ['file.mat', 'file.mat'],
+        'label': ['normal', 'normal']
+    })
+    viewer.data = df
+    viewer.populate_file_list()
+    assert viewer.file_list.count() == 1
+    text = viewer.file_list.item(0).text()
+    assert 'file.mat' in text
+    assert 'normal' in text


### PR DESCRIPTION
## Summary
- add DataViewer dialog for visualizing train/test data
- integrate viewer with main window and expose from gui package
- document visualization feature in README
- add tests for viewer

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d0bb45a483308d21e127fa4505c4