### PR TITLE
Fix DataViewer selection and use main window paths

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -260,7 +260,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def open_viewer(self):
         """Launch the :class:`DataViewer` dialog."""
-        viewer = DataViewer(self)
+        viewer = DataViewer(
+            self,
+            train_folder=self.train_edit.text(),
+            test_folder=self.test_edit.text(),
+        )
         viewer.exec_()
 
     def select_train_folder(self):


### PR DESCRIPTION
## Summary
- propagate selected train/test paths to `DataViewer`
- show initial folder contents when opening the viewer
- ensure file listing works with pandas 2 tuples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d32c7cc483309f3b549964c85c7e