### PR TITLE
Add resize and max/min buttons to viewer dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,6 @@ Use the **Visualize Data** button to explore sensor data before training. A new
 window lets you load either train or test folders. Select a file from the list
 and choose which sensors to plot to quickly inspect the raw signals. The viewer
 now includes the standard matplotlib toolbar so you can zoom or pan directly in
-the plot for a smoother exploration experience.
+the plot for a smoother exploration experience. The window can be resized and
+supports minimise/maximise buttons so you can view the plots full screen if
+needed.

--- a/gui/data_viewer.py
+++ b/gui/data_viewer.py
@@ -12,6 +12,11 @@ class DataViewer(QtWidgets.QDialog):
     def __init__(self, parent=None, train_folder="", test_folder=""):
         super().__init__(parent)
         self.setWindowTitle("Data Viewer")
+        self.setWindowFlags(
+            self.windowFlags()
+            | QtCore.Qt.WindowMinimizeButtonHint
+            | QtCore.Qt.WindowMaximizeButtonHint
+        )
         self.resize(800, 600)
         self.data = pd.DataFrame()
         self.paths = {"Train": train_folder, "Test": test_folder}

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -248,6 +248,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         dialog = QtWidgets.QDialog(self)
         dialog.setWindowTitle("Confusion Matrix")
+        dialog.setWindowFlags(
+            dialog.windowFlags()
+            | QtCore.Qt.WindowMinimizeButtonHint
+            | QtCore.Qt.WindowMaximizeButtonHint
+        )
         layout = QtWidgets.QVBoxLayout(dialog)
 
         canvas = FigureCanvasQTAgg(fig)


### PR DESCRIPTION
## Summary
- allow Data Viewer window to be resized, minimised and maximised
- enable same window hints on confusion matrix dialog
- document viewer improvements in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ffe07ce48330a06f8099f67f0696