### PR TITLE
Fix viewer plot scaling on resize

### DIFF
--- a/gui/data_viewer.py
+++ b/gui/data_viewer.py
@@ -81,6 +81,7 @@ class DataViewer(QtWidgets.QDialog):
         self.figure = plt.Figure(figsize=(5, 4))
         self.canvas = FigureCanvasQTAgg(self.figure)
         self.toolbar = NavigationToolbar2QT(self.canvas, self)
+        self.canvas.mpl_connect("resize_event", self._on_resize)
 
         right = QtWidgets.QWidget()
         vbox = QtWidgets.QVBoxLayout(right)
@@ -166,4 +167,10 @@ class DataViewer(QtWidgets.QDialog):
                 )
         ax.set_xlabel("Sample")
         ax.legend()
+        self.figure.tight_layout()
         self.canvas.draw()
+
+    def _on_resize(self, event):
+        """Ensure axes adjust correctly when the window is resized."""
+        self.figure.tight_layout()
+        self.canvas.draw_idle()

--- a/tests/test_data_viewer.py
+++ b/tests/test_data_viewer.py
@@ -30,3 +30,21 @@ def test_viewer_populates_list():
     text = viewer.file_list.item(0).text()
     assert 'file.mat' in text
     assert 'normal' in text
+
+
+def test_resize_event_refreshes_plot():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    viewer = DataViewer()
+    df = pd.DataFrame({
+        'sample_num': [0, 1],
+        'Acc_X': [0, 1],
+        'source_file': ['file.mat', 'file.mat'],
+        'folder': ['f', 'f'],
+        'label': ['normal', 'normal']
+    })
+    viewer.data = df
+    viewer.populate_file_list()
+    viewer.file_list.setCurrentRow(0)
+    viewer.update_plot()
+    viewer._on_resize(None)


### PR DESCRIPTION
## Summary
- connect canvas resize event in `DataViewer`
- adjust axes with `tight_layout` on resize
- test resize event handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a049820288330941d2fca4a05c743